### PR TITLE
Changed dependency to fall in line with the file transfer plugin 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
 
   <name>cordova-plugin-zip</name>
   <description>Unzips zip files</description>
-  <dependency id="org.apache.cordova.file" version=">=1.0.1" />
+  <dependency id="cordova-plugin-file" version=">=1.0.1" />
 
   <js-module src="zip.js" name="Zip">
     <clobbers target="zip" />


### PR DESCRIPTION
Changed dep to more recent file transfer plugin so you dont get a double of org.apache.cordova.file and cordova-plugin-file