### PR TITLE
Handle zip traversal vulnerability

### DIFF
--- a/src/android/Zip.java
+++ b/src/android/Zip.java
@@ -126,6 +126,13 @@ public class Zip extends CordovaPlugin {
                    dir.mkdirs();
                 } else {
                     File file = new File(outputDirectory + compressedName);
+                    String canonicalPath = file.getCanonicalPath();
+                    if (!canonicalPath.startsWith(outputDirectory)) {
+                        String errorMessage = "Zip traversal security error";
+                        callbackContext.error(errorMessage);
+                        Log.e(LOG_TAG, errorMessage);
+                        return;
+                    }
                     file.getParentFile().mkdirs();
                     if(file.exists() || file.createNewFile()){
                         Log.w("Zip", "extracting: " + file.getPath());


### PR DESCRIPTION
Fixes #91 by checking the file path as described in [this article](https://support.google.com/faqs/answer/9294009)